### PR TITLE
Update gettersSetters.ts

### DIFF
--- a/modulo-05/aula-57-getters-setters/gettersSetters.ts
+++ b/modulo-05/aula-57-getters-setters/gettersSetters.ts
@@ -75,7 +75,7 @@ const estudante_01 = new Estudante_01('Glaucia Lemos', 5, 'Sistema da Informaç�
 console.log(estudante_01);
 
 // Setter call
-estudante_01.curso = 'Análise e Desenvolvimento de Sistemas';
+estudante_01.cursos = 'Análise e Desenvolvimento de Sistemas';
 
 // Getter call
 console.log('Curso atualizado...:', estudante_01.cursos)


### PR DESCRIPTION
Apenas um pequeno detalhe que acredito ter passado despercebido.
O setter não estava sendo utilizado, pois o novo valor estava sendo passado diretamente para a propriedade.
Caso a propriedade "curso" fosse "private" ou "protected" geraria um erro.